### PR TITLE
Reorder skills #86

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,9 +1022,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.9.6.tgz",
-      "integrity": "sha512-TcdM3xc7weMrwTawuG3BTjtVE3mQLXUPQ9CxTbSKOrhn3QAcqCJ2fz+IIv25wztzUnhNZat7hr655YJa61F3zg==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.2.tgz",
+      "integrity": "sha512-ZLwsFnNm3WpIARU1aLFtufjMHsmEnc8TjtrfAjmbgMbeoyR+LuQoyESoNdTfeDhL6IdY12SpeycXMgSgl8XGXA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -10048,6 +10048,21 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "react-beautiful-dnd": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-11.0.3.tgz",
+          "integrity": "sha512-2FX2SnOlKMmfn90xUHCav7cxRWXwY7FeRa6TzdxWeX7DdP5JTvVQcsWgiOkdbJSj+J+1q1nA9QO4/HQ52D0DAA==",
+          "requires": {
+            "@babel/runtime-corejs2": "^7.4.4",
+            "css-box-model": "^1.1.2",
+            "memoize-one": "^5.0.4",
+            "raf-schd": "^4.0.0",
+            "react-redux": "^7.0.3",
+            "redux": "^4.0.1",
+            "tiny-invariant": "^1.0.4",
+            "use-memo-one": "^1.1.0"
+          }
         }
       }
     },
@@ -12484,18 +12499,17 @@
       }
     },
     "react-beautiful-dnd": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-11.0.3.tgz",
-      "integrity": "sha512-2FX2SnOlKMmfn90xUHCav7cxRWXwY7FeRa6TzdxWeX7DdP5JTvVQcsWgiOkdbJSj+J+1q1nA9QO4/HQ52D0DAA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz",
+      "integrity": "sha512-87It8sN0ineoC3nBW0SbQuTFXM6bUqM62uJGY4BtTf0yzPl8/3+bHMWkgIe0Z6m8e+gJgjWxefGRVfpE3VcdEg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.4.4",
-        "css-box-model": "^1.1.2",
-        "memoize-one": "^5.0.4",
-        "raf-schd": "^4.0.0",
-        "react-redux": "^7.0.3",
-        "redux": "^4.0.1",
-        "tiny-invariant": "^1.0.4",
-        "use-memo-one": "^1.1.0"
+        "@babel/runtime": "^7.8.4",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.1.1",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash": "^4.17.15",
     "material-table": "^1.57.2",
     "react": "^16.13.1",
+    "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.13.1",
     "react-firebase-hooks": "^2.1.1",
     "react-hook-form": "^5.3.1",

--- a/src/components/LivePreviewerComponents/EmptyNotice.jsx
+++ b/src/components/LivePreviewerComponents/EmptyNotice.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Typography } from "@material-ui/core";
 
-const EmptyNotice = ({ items, children }) => {
+const EmptyNotice = ({ items, children, className }) => {
   return (
-    <div>
+    <div className={className}>
       {items.length === 0 && (
         <Typography
           color={items.length > 0 ? "primary" : "secondary"}

--- a/src/components/LivePreviewerComponents/Experience.jsx
+++ b/src/components/LivePreviewerComponents/Experience.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled from "@emotion/styled";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/components/LivePreviewerComponents/Experience.jsx
+++ b/src/components/LivePreviewerComponents/Experience.jsx
@@ -26,15 +26,6 @@ const Experience = ({
   const [currentItemId, setCurrentItemId] = useState(null);
   const [skillsState, setSkillsState] = React.useState(experience.skills || []);
   const [descriptionState, setDescriptionState] = React.useState();
-
-  useEffect(() => {
-    if (currentItemId) {
-      const currentSkills = experience.find((e) => e.id === currentItemId).skills;
-      setSkillsState(currentSkills.map((s) => s.name));
-    } else {
-      setSkillsState([]);
-    }
-  }, [experience, currentItemId]);
   const methods = useForm({});
   const { control, getValues, reset } = methods;
 

--- a/src/components/LivePreviewerComponents/Experience.jsx
+++ b/src/components/LivePreviewerComponents/Experience.jsx
@@ -140,7 +140,6 @@ const Experience = ({
         <SkillsSelectFormField
           onSkillsChanged={setSkillsState}
           skills={skillsState}
-          label="Skills"
           formControl={control}
           formRules={{ required: true }}
           name="skills"

--- a/src/components/LivePreviewerComponents/Skills.jsx
+++ b/src/components/LivePreviewerComponents/Skills.jsx
@@ -66,7 +66,6 @@ const Skills = ({ skills, onSubmit }) => {
         <SkillsSelectFormField
           onSkillsChanged={setSkillsState}
           skills={skillsState}
-          label="Skills"
           formControl={control}
           formRules={{ required: true }}
           name="skills"

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { TextField } from "@material-ui/core";
 import styled from "@emotion/styled";
@@ -14,6 +14,8 @@ const AUTOCOMPLETE_REASONS = {
 
 // TODO: Deprecate label prop
 const SkillsSelect = ({ value, onChange, label }) => {
+  const skillsWrapperRef = useRef();
+  const oldValueLength = useRef(value.length);
   const renderInput = (params) => (
     <TextField {...params} placeholder="Add a library, framework, skill..." />
   );
@@ -60,11 +62,31 @@ const SkillsSelect = ({ value, onChange, label }) => {
 
   const onSkillDelete = (index) => onChange(value.filter((skill, i) => index !== i));
 
+  const handleSkillsWrapperRef = (droppableRefHandler) => (ref) => {
+    droppableRefHandler(ref);
+    skillsWrapperRef.current = ref;
+  };
+
+  useEffect(() => {
+    if (value.length > oldValueLength.current) {
+      const { current: skillsWrapper } = skillsWrapperRef;
+      skillsWrapper.scrollTo({
+        left: skillsWrapper.scrollWidth,
+        behavior: "smooth",
+      });
+    }
+
+    oldValueLength.current = value.length;
+  }, [value]);
+
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="droppable" direction="horizontal">
         {(provided) => (
-          <SkillsWrapper ref={provided.innerRef} {...provided.droppableProps}>
+          <SkillsWrapper
+            ref={handleSkillsWrapperRef(provided.innerRef)}
+            {...provided.droppableProps}
+          >
             {value.map(({ name }, index) => (
               <Draggable key={name} draggableId={name} index={index}>
                 {({ draggableProps, dragHandleProps, innerRef }, { isDragging }) => (
@@ -125,7 +147,7 @@ const SkillsWrapper = styled.div`
   &::after {
     content: "";
     display: block;
-    width: 30px;
+    width: 8px;
     height: 100%;
     flex: 1 0 auto;
   }

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -89,7 +89,7 @@ const SkillsSelect = ({ value, onChange }) => {
           >
             {value.map(({ name }, index) => (
               <Draggable key={name} draggableId={name} index={index}>
-                {({ draggableProps, dragHandleProps, innerRef }, { isDragging }) => (
+                {({ draggableProps, dragHandleProps, innerRef }) => (
                   <CustomChip
                     label={name}
                     size="small"
@@ -97,7 +97,6 @@ const SkillsSelect = ({ value, onChange }) => {
                     color="secondary"
                     ref={innerRef}
                     style={draggableProps.style}
-                    isDragging={isDragging}
                     onDelete={() => onSkillDelete(index)}
                     {...draggableProps}
                     {...dragHandleProps}

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -13,8 +13,7 @@ const AUTOCOMPLETE_REASONS = {
   REMOVE: "remove-option",
 };
 
-// TODO: Deprecate label prop
-const SkillsSelect = ({ value, onChange, label }) => {
+const SkillsSelect = ({ value, onChange }) => {
   const skillsWrapperRef = useRef();
   const oldValueLength = useRef(value.length);
   const renderInput = (params) => (

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { TextField, InputLabel } from "@material-ui/core";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import { TextField } from "@material-ui/core";
+import styled from "@emotion/styled";
 import { Autocomplete } from "@material-ui/lab";
 import Chip from "@material-ui/core/Chip";
 import { skillsConstants } from "../../config/skills.constants";
@@ -10,25 +12,10 @@ const AUTOCOMPLETE_REASONS = {
   REMOVE: "remove-option",
 };
 
+// TODO: Deprecate label prop
 const SkillsSelect = ({ value, onChange, label }) => {
-  const renderSelectedSkills = (currentSkills, getTagProps) =>
-    currentSkills.map(({ name }, index) => (
-      <Chip
-        key={name}
-        label={name}
-        size="small"
-        variant="outlined"
-        color="secondary"
-        {...getTagProps({ index })}
-      />
-    ));
-
   const renderInput = (params) => (
-    <TextField
-      {...params}
-      variant="outlined"
-      placeholder="Add frameworks, libraries, technologies..."
-    />
+    <TextField {...params} placeholder="Add a library, framework, skill..." />
   );
 
   const onAutocompleteChange = (event, inputValue, reason) => {
@@ -56,26 +43,87 @@ const SkillsSelect = ({ value, onChange, label }) => {
 
   const getOptionSelected = (option, skill) => option === skill.name;
 
+  const reorderSkills = (from, to) => {
+    const skillList = [...value];
+
+    // Swap position
+    skillList.splice(to, 0, skillList.splice(from, 1)[0]);
+
+    onChange(skillList);
+  };
+
   return (
-    <>
-      {label && <InputLabel id="skill-label">{label}</InputLabel>}
+    <DragDropContext
+      onDragEnd={({ source, destination }) =>
+        reorderSkills(source.index, destination.index)
+      }
+    >
+      <Droppable droppableId="droppable" direction="horizontal">
+        {(provided) => (
+          <SkillsWrapper ref={provided.innerRef} {...provided.droppableProps}>
+            {value.map(({ name }, index) => (
+              <Draggable key={name} draggableId={name} index={index}>
+                {({ draggableProps, dragHandleProps, innerRef }, { isDragging }) => (
+                  <CustomChip
+                    label={name}
+                    size="small"
+                    variant="outlined"
+                    color="secondary"
+                    ref={innerRef}
+                    style={draggableProps.style}
+                    isDragging={isDragging}
+                    onDelete={() => {}}
+                    {...draggableProps}
+                    {...dragHandleProps}
+                  />
+                )}
+              </Draggable>
+            ))}
+          </SkillsWrapper>
+        )}
+      </Droppable>
 
       <Autocomplete
         id="skill-list-autocomplete"
         multiple
         freeSolo
-        fullWidth
         disableClearable
         disableCloseOnSelect
-        options={skillsConstants}
+        fullWidth
         value={value}
-        renderTags={renderSelectedSkills}
+        options={skillsConstants}
         renderInput={renderInput}
         onChange={onAutocompleteChange}
         getOptionSelected={getOptionSelected}
+        renderTags={() => null}
       />
-    </>
+    </DragDropContext>
   );
 };
+
+const CustomChip = styled(Chip)`
+  margin-right: 8px;
+  background-color: #fff;
+`;
+
+const SkillsWrapper = styled.div`
+  display: flex;
+  height: 50px;
+  flex: 1 1 auto;
+  overflow: auto;
+  align-items: center;
+  border-radius: 4px;
+  border: 1px solid #c4c4c4;
+  padding: 0 8px;
+  margin-bottom: 8px;
+
+  &::after {
+    content: "";
+    display: block;
+    width: 30px;
+    height: 100%;
+    flex: 1 0 auto;
+  }
+`;
 
 export default SkillsSelect;

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -52,6 +52,8 @@ const SkillsSelect = ({ value, onChange, label }) => {
     onChange(skillList);
   };
 
+  const onSkillDelete = (index) => onChange(value.filter((skill, i) => index !== i));
+
   return (
     <DragDropContext
       onDragEnd={({ source, destination }) =>
@@ -72,7 +74,7 @@ const SkillsSelect = ({ value, onChange, label }) => {
                     ref={innerRef}
                     style={draggableProps.style}
                     isDragging={isDragging}
-                    onDelete={() => {}}
+                    onDelete={() => onSkillDelete(index)}
                     {...draggableProps}
                     {...dragHandleProps}
                   />

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 import { Autocomplete } from "@material-ui/lab";
 import Chip from "@material-ui/core/Chip";
 import { skillsConstants } from "../../config/skills.constants";
+import EmptyNotice from "./EmptyNotice";
 
 const AUTOCOMPLETE_REASONS = {
   ADD: "select-option", // Added via dropdown/select options
@@ -105,6 +106,11 @@ const SkillsSelect = ({ value, onChange, label }) => {
                 )}
               </Draggable>
             ))}
+
+            <CustomEmptyNotice items={value}>
+              Use the text field below to add skills
+            </CustomEmptyNotice>
+
             {provided.placeholder}
           </SkillsWrapper>
         )}
@@ -151,6 +157,11 @@ const SkillsWrapper = styled.div`
     height: 100%;
     flex: 1 0 auto;
   }
+`;
+
+const CustomEmptyNotice = styled(EmptyNotice)`
+  opacity: 0.6;
+  font-size: 13px;
 `;
 
 export default SkillsSelect;

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -52,14 +52,16 @@ const SkillsSelect = ({ value, onChange, label }) => {
     onChange(skillList);
   };
 
+  const onDragEnd = ({ source, destination }) => {
+    if (source && destination) {
+      reorderSkills(source.index, destination.index);
+    }
+  };
+
   const onSkillDelete = (index) => onChange(value.filter((skill, i) => index !== i));
 
   return (
-    <DragDropContext
-      onDragEnd={({ source, destination }) =>
-        reorderSkills(source.index, destination.index)
-      }
-    >
+    <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="droppable" direction="horizontal">
         {(provided) => (
           <SkillsWrapper ref={provided.innerRef} {...provided.droppableProps}>
@@ -81,6 +83,7 @@ const SkillsSelect = ({ value, onChange, label }) => {
                 )}
               </Draggable>
             ))}
+            {provided.placeholder}
           </SkillsWrapper>
         )}
       </Droppable>

--- a/src/components/LivePreviewerComponents/SkillsSelectFormField.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelectFormField.jsx
@@ -5,7 +5,6 @@ import SkillsSelect from "./SkillsSelect";
 const SkillsSelectFormField = ({
   skills,
   onSkillsChanged,
-  label,
   formControl,
   formRules,
   name,
@@ -24,7 +23,6 @@ const SkillsSelectFormField = ({
       name={name}
       onChange={onChange}
       defaultValue={skills}
-      label={label}
     />
   );
 };


### PR DESCRIPTION
As a side-effect of introducing this feature, the input that adds/removes skills needed to be changed.

At first, I tried to implement my own Drag and Drop system, but due to the added complexity of ordering a wrapped list of skill `Chip`s, I started encountering many edge-cases so I decided to use a library that is already out there solving the problem.
But turns out, the library also doesn't support wrapped lists, and this appears to be a tricky thing to solve, so in order to keep it simple, I have changed it to a horizontal list, so the library works flawlessly.

In order to ensure a good UX, I have implemented some logic to auto-scroll the skills list to the end when a new skill is added, so the user doesn't have to keep scrolling to see if his skill was actually added or not.

It looks like this now:
![Screenshot 2020-06-17 at 10 49 41](https://user-images.githubusercontent.com/5693916/84877055-481b2200-b088-11ea-9438-c36b9f539c94.png)

The adding/removing behavior stays the same as it was before.