### PR TITLE
Fade modal's backdrop

### DIFF
--- a/src/components/LivePreviewerComponents/ModalWrapper.jsx
+++ b/src/components/LivePreviewerComponents/ModalWrapper.jsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { FormContext } from "react-hook-form";
 import styled from "@emotion/styled";
-import { Modal, Fade } from "@material-ui/core";
+import { Modal, Fade, Backdrop } from "@material-ui/core";
 import ModalActionButtons from "./ModalActionButtons";
+
+const BackdropComponent = ({ open, ...backdropProps }) => (
+  <Fade in={open}>
+    <Backdrop {...backdropProps} />
+  </Fade>
+);
 
 const EditModalWrapper = ({
   isOpen,
@@ -20,6 +26,7 @@ const EditModalWrapper = ({
     <CustomModal
       open={isOpen}
       onClose={() => onRequestClose(false)}
+      BackdropComponent={BackdropComponent}
       aria-labelledby="modal"
       aria-describedby="modal"
     >


### PR DESCRIPTION
After the latest UI changes PR (#108), I have added a fade effect on the modal, but then I noticed that the backdrop wasn't fading, so this PR fixes that.