### PR TITLE
Personal info layout overhaul #80

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -14,6 +14,10 @@ const InternCard = ({ children, className, ...props }) => {
 const CardContainer = styled(Card)`
   position: relative;
   margin: 24px 0;
+
+  .MuiCardContent-root {
+    padding-bottom: 16px;
+  }
 `;
 
 export default InternCard;

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -3,9 +3,9 @@ import styled from "@emotion/styled";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 
-const InternCard = ({ children, ...props }) => {
+const InternCard = ({ children, className, ...props }) => {
   return (
-    <CardContainer {...props}>
+    <CardContainer {...props} className={className}>
       <CardContent>{children}</CardContent>
     </CardContainer>
   );

--- a/src/components/LivePreviewerComponents/Education.jsx
+++ b/src/components/LivePreviewerComponents/Education.jsx
@@ -6,6 +6,8 @@ import { TextField, Typography } from "@material-ui/core";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import { DatePicker } from "@material-ui/pickers";
+import Box from "@material-ui/core/Box";
+import Divider from "@material-ui/core/Divider";
 import Card from "../Card";
 import Input from "../Input";
 import { DATE_FIELD_DEFAULT_VALUE } from "../constants";
@@ -13,8 +15,6 @@ import EditModalWrapper from "./ModalWrapper";
 import EmptyNotice from "./EmptyNotice";
 import EducationItem from "./EducationItem";
 import ActionIcon from "./ActionIcon";
-import Box from "@material-ui/core/Box";
-import Divider from "@material-ui/core/Divider";
 
 const Education = ({ education, onSubmit, onUpdateEducation, onDeleteHandler }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -61,7 +61,7 @@ const Education = ({ education, onSubmit, onUpdateEducation, onDeleteHandler }) 
           )}
         </>
       ))}
-      <EmptyNotice items={education} />
+      <EmptyNotice show={education.length === 0} icon={faPlus} />
 
       <EditModalWrapper
         isOpen={isEditing}

--- a/src/components/LivePreviewerComponents/EmptyNotice.jsx
+++ b/src/components/LivePreviewerComponents/EmptyNotice.jsx
@@ -1,19 +1,31 @@
 import React from "react";
 import { Typography } from "@material-ui/core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import styled from "@emotion/styled";
 
-const EmptyNotice = ({ items, children, className }) => {
+const EmptyNotice = ({ show, color, children, icon, className }) => {
   return (
     <div className={className}>
-      {items.length === 0 && (
-        <Typography
-          color={items.length > 0 ? "primary" : "secondary"}
-          variant="body1"
-        >
-          {children ? children : "Click on the + icon to add new items"}
+      {show && (
+        <Typography color={color || "secondary"} variant="body1">
+          {children ? (
+            children
+          ) : (
+            <span>
+              Click on the {icon && <EmptyIcon icon={icon} />} icon to add new items
+            </span>
+          )}
         </Typography>
       )}
     </div>
   );
 };
+
+const EmptyIcon = styled(FontAwesomeIcon)`
+  position: relative;
+  top: -1px;
+  font-size: 11px;
+  opacity: 0.7;
+`;
 
 export default EmptyNotice;

--- a/src/components/LivePreviewerComponents/Experience.jsx
+++ b/src/components/LivePreviewerComponents/Experience.jsx
@@ -71,7 +71,8 @@ const Experience = ({
           )}
         </>
       ))}
-      <EmptyNotice items={experience} />
+
+      <EmptyNotice show={experience.length === 0} icon={faPlus} />
 
       <EditModalWrapper
         isOpen={isEditing}

--- a/src/components/LivePreviewerComponents/LivePreviewerTemplate.jsx
+++ b/src/components/LivePreviewerComponents/LivePreviewerTemplate.jsx
@@ -98,13 +98,20 @@ const LivePreviewerTemplate = ({ data }) => {
         id={dataState.id}
       />
       <>
-        {dataState.personalia && (
-          <TopSection personalia={dataState.personalia} onSubmit={onSubmitSection} />
-        )}
-        <Introduction
-          introduction={dataState.introduction}
-          onSubmit={onSubmitSection}
-        />
+        <ColumnContainer>
+          {dataState.personalia && (
+            <TopSection
+              personalia={dataState.personalia}
+              onSubmit={onSubmitSection}
+            />
+          )}
+
+          <Introduction
+            introduction={dataState.introduction}
+            onSubmit={onSubmitSection}
+          />
+        </ColumnContainer>
+
         <ColumnContainer>
           {dataState.skills && (
             <Skills skills={dataState.skills} onSubmit={onSubmitSection} />

--- a/src/components/LivePreviewerComponents/LivePreviewerTemplate.jsx
+++ b/src/components/LivePreviewerComponents/LivePreviewerTemplate.jsx
@@ -184,6 +184,10 @@ const ColumnContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-gap: 8px;
+
+  @media (max-width: 970px) {
+    display: block;
+  }
 `;
 
 export default LivePreviewerTemplate;

--- a/src/components/LivePreviewerComponents/SideProjects.jsx
+++ b/src/components/LivePreviewerComponents/SideProjects.jsx
@@ -63,7 +63,7 @@ const SideProjects = ({
         </React.Fragment>
       ))}
 
-      <EmptyNotice items={projects} />
+      <EmptyNotice show={projects.length === 0} icon={faPlus} />
 
       <EditModalWrapper
         isOpen={isEditing}

--- a/src/components/LivePreviewerComponents/Skills.jsx
+++ b/src/components/LivePreviewerComponents/Skills.jsx
@@ -46,9 +46,7 @@ const Skills = ({ skills, onSubmit }) => {
         ))}
       </SkillsContainer>
 
-      <EmptyNotice items={skills}>
-        Click on the pen icon to add new skills
-      </EmptyNotice>
+      <EmptyNotice show={skills.length === 0} icon={faPen} />
 
       <EditModalWrapper
         isOpen={isEditing}

--- a/src/components/LivePreviewerComponents/SkillsSelect.jsx
+++ b/src/components/LivePreviewerComponents/SkillsSelect.jsx
@@ -105,7 +105,7 @@ const SkillsSelect = ({ value, onChange }) => {
               </Draggable>
             ))}
 
-            <CustomEmptyNotice items={value}>
+            <CustomEmptyNotice show={value.length === 0}>
               Use the text field below to add skills
             </CustomEmptyNotice>
 

--- a/src/components/LivePreviewerComponents/Topsection.jsx
+++ b/src/components/LivePreviewerComponents/Topsection.jsx
@@ -13,7 +13,7 @@ import AvatarSelector from "../FormComponents/AvatarSelector";
 import { DATE_FIELD_DEFAULT_VALUE } from "../constants";
 import EditModalWrapper from "./ModalWrapper";
 import ActionIcon from "./ActionIcon";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import EmptyNotice from "./EmptyNotice";
 
 const isInfoEmpty = ({ firstName, lastName, email, city }) =>
   !(firstName || lastName || email || city);
@@ -38,11 +38,7 @@ const TopSection = ({ personalia, onSubmit }) => {
 
   const renderInfo = () => {
     if (isInfoEmpty(personalia)) {
-      return (
-        <Typography color="secondary" variant="body1">
-          Click the <EmptyIcon icon={faPen} /> icon to add your personal information
-        </Typography>
-      );
+      return <EmptyNotice show icon={faPen} />;
     }
 
     return (
@@ -206,13 +202,6 @@ const CustomActionIcon = styled(ActionIcon)`
   position: absolute;
   top: 16px;
   right: 16px;
-`;
-
-const EmptyIcon = styled(FontAwesomeIcon)`
-  position: relative;
-  top: -1px;
-  font-size: 11px;
-  opacity: 0.7;
 `;
 
 export default TopSection;

--- a/src/components/LivePreviewerComponents/Topsection.jsx
+++ b/src/components/LivePreviewerComponents/Topsection.jsx
@@ -32,19 +32,24 @@ const TopSection = ({ personalia, onSubmit }) => {
 
   return (
     <TopSectionContainer>
-      <LeftSection>
-        <Typography variant="h4">
-          Hi, I am &nbsp; <b> {personalia.firstName}</b>
-        </Typography>
-        <Typography variant="h4">Frontend expert</Typography>
-        <Typography variant="h5">
-          {personalia.city} region - NL - {getFormattedDate(personalia.dateOfBirth)}
-        </Typography>
-      </LeftSection>
+      <AvatarWrapper>
+        <AvatarImg
+          src={(avatars.find((x) => x.name === personalia.avatar) || avatars[6]).img}
+          alt="Avatar"
+        />
+      </AvatarWrapper>
 
-      <Avatar
-        src={(avatars.find((x) => x.name === personalia.avatar) || avatars[6]).img}
-      />
+      <MainInfo>
+        <Typography variant="h2">
+          {personalia.firstName} {personalia.lastName}
+        </Typography>
+
+        <Typography variant="h5">{personalia.email}</Typography>
+      </MainInfo>
+
+      <OtherInfo variant="h7">
+        {personalia.city} <Separator /> {getFormattedDate(personalia.dateOfBirth)}
+      </OtherInfo>
 
       <CustomActionIcon
         onClick={() => setIsEditing((prevState) => !prevState)}
@@ -123,20 +128,53 @@ const TopSection = ({ personalia, onSubmit }) => {
   );
 };
 
-const LeftSection = styled.div`
-  padding: 24px;
-`;
-
-const Avatar = styled.img`
-  margin-right: 20px;
-  height: 150px;
-  position: absolute;
-  right: 0;
-  top: 70px;
-`;
-
 const TopSectionContainer = styled(Card)`
+  &,
+  .MuiCardContent-root {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
+const AVATAR_SIZE = 200;
+const AvatarWrapper = styled.div`
   display: flex;
+  align-items: center;
+  justify-content: center;
+  height: ${AVATAR_SIZE}px;
+  width: ${AVATAR_SIZE}px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 4px solid rgba(0, 0, 0, 0.7);
+`;
+
+const AvatarImg = styled.img`
+  width: 60%;
+  margin-top: 50%;
+  margin-left: 10%;
+`;
+
+const MainInfo = styled.div`
+  margin-top: 8px;
+  text-align: center;
+`;
+
+const OtherInfo = styled(Typography)`
+  display: flex;
+  margin-top: 16px;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Separator = styled.div`
+  width: 20px;
+  height: 1px;
+  background-color: currentColor;
+  margin: 0 8px;
+  opacity: 0.75;
 `;
 
 const CustomActionIcon = styled(ActionIcon)`

--- a/src/components/LivePreviewerComponents/Topsection.jsx
+++ b/src/components/LivePreviewerComponents/Topsection.jsx
@@ -13,6 +13,10 @@ import AvatarSelector from "../FormComponents/AvatarSelector";
 import { DATE_FIELD_DEFAULT_VALUE } from "../constants";
 import EditModalWrapper from "./ModalWrapper";
 import ActionIcon from "./ActionIcon";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const isInfoEmpty = ({ firstName, lastName, email, city }) =>
+  !(firstName || lastName || email || city);
 
 const TopSection = ({ personalia, onSubmit }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -30,26 +34,47 @@ const TopSection = ({ personalia, onSubmit }) => {
     }
   }, [personalia, getValues, reset]);
 
+  const { city, dateOfBirth } = personalia;
+
+  const renderInfo = () => {
+    if (isInfoEmpty(personalia)) {
+      return (
+        <Typography color="secondary" variant="body1">
+          Click the <EmptyIcon icon={faPen} /> icon to add your personal information
+        </Typography>
+      );
+    }
+
+    return (
+      <>
+        <AvatarWrapper>
+          <AvatarImg
+            src={
+              (avatars.find((x) => x.name === personalia.avatar) || avatars[6]).img
+            }
+            alt="Avatar"
+          />
+        </AvatarWrapper>
+
+        <MainInfo>
+          <Typography variant="h2">
+            {personalia.firstName} {personalia.lastName}
+          </Typography>
+
+          <Typography variant="h5">{personalia.email}</Typography>
+        </MainInfo>
+
+        <OtherInfo variant="h7">
+          {city} {city && dateOfBirth && <Separator />}{" "}
+          {getFormattedDate(dateOfBirth)}
+        </OtherInfo>
+      </>
+    );
+  };
+
   return (
     <TopSectionContainer>
-      <AvatarWrapper>
-        <AvatarImg
-          src={(avatars.find((x) => x.name === personalia.avatar) || avatars[6]).img}
-          alt="Avatar"
-        />
-      </AvatarWrapper>
-
-      <MainInfo>
-        <Typography variant="h2">
-          {personalia.firstName} {personalia.lastName}
-        </Typography>
-
-        <Typography variant="h5">{personalia.email}</Typography>
-      </MainInfo>
-
-      <OtherInfo variant="h7">
-        {personalia.city} <Separator /> {getFormattedDate(personalia.dateOfBirth)}
-      </OtherInfo>
+      {renderInfo()}
 
       <CustomActionIcon
         onClick={() => setIsEditing((prevState) => !prevState)}
@@ -181,6 +206,13 @@ const CustomActionIcon = styled(ActionIcon)`
   position: absolute;
   top: 16px;
   right: 16px;
+`;
+
+const EmptyIcon = styled(FontAwesomeIcon)`
+  position: relative;
+  top: -1px;
+  font-size: 11px;
+  opacity: 0.7;
 `;
 
 export default TopSection;


### PR DESCRIPTION
# How it looks
![Screenshot 2020-06-25 at 11 40 51](https://user-images.githubusercontent.com/5693916/85695921-c1de8b80-b6d8-11ea-9afe-3df615d10a3f.png)
![Screenshot 2020-06-25 at 11 39 46](https://user-images.githubusercontent.com/5693916/85695923-c30fb880-b6d8-11ea-8e92-9cee45bb450a.png)
![Screenshot 2020-06-25 at 11 39 34](https://user-images.githubusercontent.com/5693916/85695926-c3a84f00-b6d8-11ea-9afe-6d17f3fce435.png)

# Other changes
### EmptyNotice
- It now has a more generic `show` prop so its more flexible - doesn't depend on arrays;
- You can pass the icon that it generally refers to so it's displayed within the message.

### Other
- A breakpoint has been added to stack all `Card`s on top of each other. This aims to improve the layout on smaller screens for the first 2 columns which have 2 cards in them.