### PR TITLE
fix: rewrite logic for creating section objects in docx parser

### DIFF
--- a/src/lib/downloadResume.tsx
+++ b/src/lib/downloadResume.tsx
@@ -24,7 +24,6 @@ export default async function downloadResume(resume: Resume, type = "PDF") {
       });
       break;
     case "pdf":
-      debugger;
       const pdfTemplate = <PDFTemplate {...{ resume }} />;
       const pdf = await createPdf(pdfTemplate).toBlob();
       file = new Blob([pdf], {


### PR DESCRIPTION
Small PR that adds some typing, but also in the database a section called Certificates. We don't do anything with it yet in the viewer, but it might come in handy some point in time.

Removed a terrible unreadable reducer function and used forEach instead. 