### PR TITLE
Make skill pill max width with tooltip

### DIFF
--- a/src/components/Form/FormSkillsSelectChip.tsx
+++ b/src/components/Form/FormSkillsSelectChip.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useRef } from "react";
-import { Chip, makeStyles } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core";
 import { DropTargetMonitor, useDrag, useDrop } from "react-dnd";
+import { TruncateChip } from "../Material/truncatedChip";
 
 interface FormSkillsSelectChipProps {
   label: string;
@@ -86,7 +87,7 @@ const FormSkillsSelectChip: FunctionComponent<FormSkillsSelectChipProps> = ({
   drag(drop(ref));
 
   return (
-    <Chip
+    <TruncateChip
       size="small"
       variant="outlined"
       color="secondary"
@@ -96,8 +97,8 @@ const FormSkillsSelectChip: FunctionComponent<FormSkillsSelectChipProps> = ({
       onDelete={() => onDelete(index)}
       // Stop propagation of the mouse event to avoid it being swallowed by the autocomplete.
       // If the event is swallowed, drag & drop doesn't work.
-      onMouseDown={(event) => event.stopPropagation()}
-    />
+      onMouseDown={(event: any) => event.stopPropagation()}
+    ></TruncateChip>
   );
 };
 

--- a/src/components/LivePreviewerComponents/Skills.tsx
+++ b/src/components/LivePreviewerComponents/Skills.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useState } from "react";
-import { Box, Chip } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import { TruncateChip } from "../Material/truncatedChip";
 import { Section } from "./Section";
 import { SectionEditDialog } from "./SectionEditDialog";
 import { FormColumn, FormRow, FormSkillsSelect } from "../Form";
@@ -24,7 +25,7 @@ export const Skills: FunctionComponent<SkillsProps> = ({ skills, onSubmit }) => 
     >
       <Box display="flex" flexWrap="wrap" gridGap={8}>
         {skills.map((skill) => (
-          <Chip
+          <TruncateChip
             key={skill.name}
             size="small"
             variant="outlined"

--- a/src/components/Material/truncatedChip.tsx
+++ b/src/components/Material/truncatedChip.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Chip, Tooltip } from "@material-ui/core";
+
+const truncateLabel = (content: string) => {
+  const maxLength = 12;
+  if (content.length < maxLength) return content;
+  return `${content.substr(0, maxLength)}...`;
+};
+
+export const TruncateChip = (props: any) => {
+  const { label, limit, ...rest } = props;
+  return (
+    <Tooltip title={label}>
+      <Chip {...rest} label={truncateLabel(label)} />
+    </Tooltip>
+  );
+};


### PR DESCRIPTION
Fixes bug where skills pill would overflow and render the /live page weirdly. Truncates label to max 12 characters (+ ellipsis) and uses tooltip to showcase full label
![image](https://user-images.githubusercontent.com/85111889/121206089-7933ca00-c878-11eb-990f-287ebaee1e13.png) 
![image](https://user-images.githubusercontent.com/85111889/121206131-82249b80-c878-11eb-9248-e7e983ce54fe.png)
![image](https://user-images.githubusercontent.com/85111889/121206261-9cf71000-c878-11eb-9458-93a080842e45.png)

