### PR TITLE
fix: prevent crash when adding new item to resume with invalid date

### DIFF
--- a/src/components/LivePreviewerComponents/LivePreviewerTemplate.tsx
+++ b/src/components/LivePreviewerComponents/LivePreviewerTemplate.tsx
@@ -85,6 +85,7 @@ const LivePreviewerTemplate: FunctionComponent<LivePreviewerTemplateProps> = ({
         ...resume,
         isImport: false, // explicitly remove database import flag, but only when saving to firestore
       });
+      setResume(resume);
     } catch (e) {
       alert(`Error updating document. ${e.message}`);
     }
@@ -101,7 +102,6 @@ const LivePreviewerTemplate: FunctionComponent<LivePreviewerTemplateProps> = ({
   const handleSubmit = (resumePartial: Partial<Resume>) => {
     const newResume = { ...resume, ...resumePartial };
     updateResume(newResume);
-    setResume(newResume);
   };
 
   return (


### PR DESCRIPTION
Only set state when data ia correctly stored in Firebase