### PR TITLE
Bugfix/UI issues

### DIFF
--- a/src/components/LivePreviewerComponents/PersonaliaDialog.tsx
+++ b/src/components/LivePreviewerComponents/PersonaliaDialog.tsx
@@ -36,9 +36,6 @@ export const PersonaliaDialog: VoidFunctionComponent<PersonaliaDialogProps> = ({
           <FormTextField required name="lastName" label="Last name*" />
         </FormRow>
         <FormRow>
-          <FormTextField required name="email" label="Email*" />
-        </FormRow>
-        <FormRow>
           <FormColumn>
             <FormTextField name="city" label="City*" />
           </FormColumn>

--- a/src/components/OverviewDrawer/OverviewDrawer.tsx
+++ b/src/components/OverviewDrawer/OverviewDrawer.tsx
@@ -25,6 +25,9 @@ const DrawerRoot = styled("div")(({ theme }) => ({
 const Content = styled("div")(({ theme }) => ({
   flexGrow: 1,
   padding: theme.spacing(3),
+  "@media (max-width: 600px)": {
+    padding: theme.spacing(1),
+  },
 }));
 
 const StyledDrawer = styled(Drawer)(({ theme }) => ({

--- a/src/components/OverviewDrawer/OverviewList.spec.tsx
+++ b/src/components/OverviewDrawer/OverviewList.spec.tsx
@@ -9,9 +9,11 @@ import { useCollection } from "react-firebase-hooks/firestore";
 import { mocked } from "jest-mock";
 import userEvent from "@testing-library/user-event";
 import { useFirebaseApp } from "../../context/FirebaseContext/FirebaseContext";
+import { useAppState } from "../../context/AppStateContext/AppStateContext";
 import { OverviewList } from "./OverviewList";
 
 jest.mock("../../context/FirebaseContext/FirebaseContext");
+jest.mock("../../context/AppStateContext/AppStateContext");
 jest.mock("react-firebase-hooks/firestore", () => ({
   ...jest.requireActual("react-firebase-hooks/firestore"),
   useCollection: jest.fn(),
@@ -61,11 +63,17 @@ describe("OverviewList", () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    mocked(useAppState).mockImplementation(() => ({
+      isDrawerOpen: true,
+      setIsDrawerOpen: jest.fn(),
+    }));
+
     mocked(useCollection).mockReturnValue([
       getExampleResumeQueryResult(),
       false,
       null,
     ] as any);
+
     mocked(useFirebaseApp).mockReturnValue({
       firebase: {
         firestore: jest.fn().mockReturnValue({ collection: jest.fn() }),

--- a/src/components/OverviewDrawer/OverviewList.tsx
+++ b/src/components/OverviewDrawer/OverviewList.tsx
@@ -104,11 +104,11 @@ const ResumeItem: VoidFunctionComponent<ResumeItemProps> = ({
       })}
       activeClassName={classes.activeLink}
       to={`/resume/${id}`}
+      onClick={() => {
+        setIsDrawerOpen(false);
+      }}
     >
       <ListItem
-        onClick={() => {
-          setIsDrawerOpen(false);
-        }}
         classes={{
           container: clsx(classes.container, {
             [classes.isArchived]: isArchived,

--- a/src/components/OverviewDrawer/OverviewList.tsx
+++ b/src/components/OverviewDrawer/OverviewList.tsx
@@ -23,6 +23,8 @@ import { useFirebaseApp } from "../../context/FirebaseContext/FirebaseContext";
 import getAvatarDataUri from "../../lib/getAvatarDataUri";
 import { Confirmation } from "../Confirmation/Confirmation";
 import { ResumeModel } from "../LivePreviewerComponents/ResumeModel";
+import { useAppState } from "../../context/AppStateContext/AppStateContext";
+
 // components
 import { TooltipIconButton } from "../Material";
 
@@ -93,6 +95,7 @@ const ResumeItem: VoidFunctionComponent<ResumeItemProps> = ({
   resume: { id, displayName, personalia, isImport, isArchived },
   onDelete,
 }) => {
+  const { setIsDrawerOpen } = useAppState();
   return (
     <NavLink
       className={clsx({
@@ -103,6 +106,9 @@ const ResumeItem: VoidFunctionComponent<ResumeItemProps> = ({
       to={`/resume/${id}`}
     >
       <ListItem
+        onClick={() => {
+          setIsDrawerOpen(false);
+        }}
         classes={{
           container: clsx(classes.container, {
             [classes.isArchived]: isArchived,

--- a/src/components/PDFBuilderComponents/PDFHeader.tsx
+++ b/src/components/PDFBuilderComponents/PDFHeader.tsx
@@ -122,7 +122,6 @@ export const PDFHeader: VoidFunctionComponent<{
 
       <PersonalInfoBox>
         <View>
-          <Text>{email}</Text>
           <Text style={styles.my_5}>{city.toUpperCase()} REGION - NL</Text>
           <Text>{age ? `${age} years old` : ""}</Text>
         </View>

--- a/src/components/layout/Nav.spec.tsx
+++ b/src/components/layout/Nav.spec.tsx
@@ -39,6 +39,7 @@ describe("Nav", () => {
       () =>
         ({
           firebase: {},
+          userRecord: { isManager: true },
         } as FirebaseAppContextType)
     );
 
@@ -70,6 +71,7 @@ describe("Nav", () => {
       () =>
         ({
           firebase: {},
+          userRecord: { isManager: true },
         } as FirebaseAppContextType)
     );
 

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -20,7 +20,7 @@ import { useAppState } from "../../context/AppStateContext/AppStateContext";
 import LogoWhite from "../../assets/images/iO-logo-white.png";
 
 const StyledLink = styled(Link)(({ theme }) => ({
-  color: theme.palette.primary.main,
+  color: theme.palette?.primary?.main,
   textDecoration: "none",
 }));
 
@@ -91,15 +91,17 @@ export const Nav: VoidFunctionComponent = () => {
       <Box>
         <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
           <Toolbar>
-            <IconButton
-              color="inherit"
-              aria-label={isDrawerOpen ? "close drawer" : "open drawer"}
-              edge="start"
-              onClick={handleDrawerToggle}
-              sx={{ marginRight: 2, display: { lg: "none" } }}
-            >
-              {isDrawerOpen ? <ChevronLeftIcon /> : <MenuIcon />}
-            </IconButton>
+            {userRecord?.isManager && (
+              <IconButton
+                color="inherit"
+                aria-label={isDrawerOpen ? "close drawer" : "open drawer"}
+                edge="start"
+                onClick={handleDrawerToggle}
+                sx={{ marginRight: 2, display: { lg: "none" } }}
+              >
+                {isDrawerOpen ? <ChevronLeftIcon /> : <MenuIcon />}
+              </IconButton>
+            )}
 
             <IconButton component={Link} to="/">
               <img src={LogoWhite} alt="iO Logo white" height={44} />

--- a/src/pages/LivePreviewerPage/LivePreviewerPage.tsx
+++ b/src/pages/LivePreviewerPage/LivePreviewerPage.tsx
@@ -66,7 +66,6 @@ const LivePreviewer: VoidFunctionComponent<LivePreviewerProps> = () => {
           <StyledSkeleton
             animation="wave"
             variant="rectangular"
-            width={1200}
             height={height}
             key={`${height}-${index}`}
           />
@@ -87,12 +86,23 @@ const LivePreviewer: VoidFunctionComponent<LivePreviewerProps> = () => {
 };
 const StyledSkeleton = styled(Skeleton)`
   margin: 8px auto;
+  @media (max-width: 600px): {
+    max-width: 315px,
+  },
+  @media (min-width: 601px): {
+    max-width: 1200px,
+  },
 `;
 
 const LivePreviewContainer = styled("div")(({ theme }) => ({
   boxSizing: "border-box",
   margin: "0 auto",
-  maxWidth: 1200,
+  "@media (max-width: 600px)": {
+    maxWidth: 315,
+  },
+  "@media (min-width: 601px)": {
+    maxWidth: 1200,
+  },
 }));
 
 export const LivePreviewerPage: VoidFunctionComponent<LivePreviewerProps> = (


### PR DESCRIPTION
- [When logging into the app as a user the open-drawer button is visible while it has no functionality #593](https://github.com/FrontMen/resumator/issues/593)
- [When you open the drawer and select a resume and close it you need to zoom out slightly to see the full with of the page again, this should not happen #592](https://github.com/FrontMen/resumator/issues/592)
- [When filtering and selecting a cv the drawer should close on select, now it stays open on mobile view #594](https://github.com/FrontMen/resumator/issues/594)
- Added unit tests.
- Removed edit email input from the CV form.
- Removed Email displaying on the iO theme.